### PR TITLE
Kill process on seneca.close

### DIFF
--- a/scripts/es-index-dojos-data.js
+++ b/scripts/es-index-dojos-data.js
@@ -23,6 +23,8 @@ seneca.ready(function() {
     if (err) {
       seneca.log.error(err);
     }
+
+    //TODO: remove seneca.close callback once issues are fixed(probably with seneca-elasticsearch)
     seneca.close(function() {
       process.exit();
     });


### PR DESCRIPTION
This is a temporary fix to kill the process. There seems to be an issue with seneca-elasticsearch
