### PR TITLE
Adding the cancellation link to event approval email template

### DIFF
--- a/email-templates/ticket-application-approved-en_US/html.ejs
+++ b/email-templates/ticket-application-approved-en_US/html.ejs
@@ -31,8 +31,13 @@
   <p> - Event date: <%= eventDate %></p>
   <p> - Event address: <%= event.address %></p>
 
-  <p>If you have any questions about the event in advance please contact the Dojo directly at <b><%= dojo.email %></b></p>
+  <p>
+    If you are unable to attend this event, please click this link to cancel your booking: 
+    <a href="<%= cancelLinkBase + '/' + event.id + '/' + applicationId %>"><%= cancelLinkBase + '/' + event.id + '/' + applicationId %></a>
+  </p>
 
+  <p>If you have any questions about the event in advance please contact the Dojo directly at <b><%= dojo.email %></b></p>
+  
   <p>Best wishes,</br>
   The CoderDojo Foundation Team</p>
 


### PR DESCRIPTION
This PR adds the cancellation link to event approval email template. This is related to:
https://github.com/CoderDojo/community-platform/issues/876, and should not be merged before: https://github.com/CoderDojo/cp-events-service/issues/96