### PR TITLE
Add referer to allow usage of API key serverside

### DIFF
--- a/dojos.js
+++ b/dojos.js
@@ -2294,6 +2294,7 @@ module.exports = function (options) {
     var options = {
       url: 'https://maps.googleapis.com/maps/api/place/autocomplete/json',
       method: 'GET',
+      headers: {'Referer': 'zen.coderdojo.com'},
       qs: {
         key: process.env.GOOGLE_MAPS_KEY,
         types: '(cities)',


### PR DESCRIPTION
Instead of allowing every domains in the API key definition, we just pass an allowed referer in headers