### PR TITLE
Fix invitation approval with kid

### DIFF
--- a/lib/add-children-parent-dojo.js
+++ b/lib/add-children-parent-dojo.js
@@ -35,7 +35,7 @@ function addChildrenParentDojo (args, done) {
               userTypes: [youthProfile.userType]
             };
 
-            seneca.act({role: plugin, cmd: 'save_usersdojos', userDojo: youthUserDojo, user: args.user}, cb);
+            seneca.act({role: plugin, cmd: 'save_usersdojos', userDojo: youthUserDojo, user: args.user, invite: args.invite}, cb);
           } else {
             return cb();
           }

--- a/lib/save-usersdojo.js
+++ b/lib/save-usersdojo.js
@@ -44,7 +44,7 @@ function cmd_save_usersdojos (args, done) {
   }
 
   function hasPermissionToUpdate (done) {
-    if (userDojo.id && !isCDF) {
+    if (userDojo.id && !isCDF && !args.invite) {
       seneca.act({role: 'cd-dojos', cmd: 'have_permissions_on_user', perm: 'dojo-admin', params: {userId: userDojo.userId}, user: args.user},
         function (err, resp) {
           if (err) return done(new Error('You do not have permission to update this association'));
@@ -128,7 +128,7 @@ function cmd_save_usersdojos (args, done) {
   }
 
   function saveNinjasUserDojo (done) {
-    seneca.act({role: plugin, cmd: 'add_children_parent_dojo', userId: userDojo.userId, dojoId: userDojo.dojoId, user: args.user}, done);
+    seneca.act({role: plugin, cmd: 'add_children_parent_dojo', userId: userDojo.userId, dojoId: userDojo.dojoId, user: args.user, invite: args.invite}, done);
   }
 }
 


### PR DESCRIPTION
bypass perm, thoughts on security @DanielBrierton ?
https://github.com/CoderDojo/cp-dojos-service/compare/master...Wardormeur:bugfix/remove-check-perm-invitation-save-userdojos?expand=1#diff-77e07861fb9a27da71c79da3658a5173R91 says it should be fine, but crafting an invite/passing it down thbrough a save_usersdojos call (directly) would allow a bypass?