### PR TITLE
Workaround for UglifyJs madness

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,8 @@ dependencies:
     - if [ "$CIRCLE_BRANCH" = "master" ]; then cd ~/ && git clone git@github.com:CoderDojo/cp-translations.git && cd cp-translations && ./build.sh; fi
   override:
     - npm install
+  post: 
+    - cd ~/cp-dojos-service && find ./node_modules/* -mtime +10950 -exec touch {} \;   
 test:
   override:
     - npm run test


### PR DESCRIPTION
https://github.com/mishoo/UglifyJS2/issues/2054
shrinkwrap was an issue because of cp-translations bumping on deploy
npm 3 is dodgy on node 0.10 and would have forced an upgrade on all microservices (same instance)
so here is a dodgy workaround