### PR TITLE
Remove flag for EB

### DIFF
--- a/dojos.js
+++ b/dojos.js
@@ -1060,6 +1060,7 @@ module.exports = function (options) {
         if (dojo.name) dojo.name = sanitizeHtml(dojo.name);
         if (dojo.countryName) dojo.countryName = sanitizeHtml(dojo.countryName);
         if (dojo.notes) dojo.notes = sanitizeHtml(dojo.notes, so.sanitizeTextArea);
+        delete dojo.eventbriteConnected;
         seneca.make$(ENTITY_NS).save$(dojo, function (err, response) {
           if (err) return done(err);
           done(null, response);


### PR DESCRIPTION
This is a ugly patchfix, but hopefully shouldn't be required after SAD deployment

Reason : backend calls to 'load', but the generic (ctrl) one, hence returning a boolean display which doesn't exists as a column, and crash saving