### PR TITLE
Bugfix/dojo users export csv perf

### DIFF
--- a/dojos.js
+++ b/dojos.js
@@ -761,6 +761,7 @@ module.exports = function (options) {
     var nameQuery = null;
     var skip = 0;
     var userListQuery = {};
+    userListQuery.fields$ = ['name', 'email', 'init_user_type', 'profile_id', 'dob', 'user_id'];
     if (query.sort$) {
       userListQuery.sort$ = query.sort$;
       delete query.sort$;
@@ -786,10 +787,14 @@ module.exports = function (options) {
       delete query.skip$;
     }
 
+    if (query.fields) {
+      userListQuery.fields$ = query.fields;
+      delete query.fields;
+    }
+
     seneca.act({role: plugin, cmd: 'load_usersdojos', query: query}, function (err, response) {
       if (err) return done(err);
       // column name must match the casing in the DB as per latest changes in seneca-postgresql-store
-      userListQuery.fields$ = ['name', 'email', 'init_user_type', 'profile_id', 'dob', 'user_id'];
       if (typeQuery) {
         response = _.filter(response, function (user) {
           return _.includes(user.userTypes, typeQuery);

--- a/lib/export-csv.js
+++ b/lib/export-csv.js
@@ -21,7 +21,6 @@ function cmd_export_dojo_users (args, callback) {
   }
   // Returns the parent email of a child
   function getParentEmail (csvData, done) {
-    var nbParents = [];
     var parentsIds = _.compact(_.map(csvData, 'Parents'));
     // Note: in case of optimisation, most parents profile are probably already loaded in getUserData
     // This query ensure that parents that don't belongs to the dojo are still reachable

--- a/lib/export-csv.js
+++ b/lib/export-csv.js
@@ -33,7 +33,7 @@ function cmd_export_dojo_users (args, callback) {
           if (user['Parents']) {
             const parentsEmails = [];
             const parentsNames = [];
-            user['Parents'].map(userId => {
+            user['Parents'].forEach(userId => {
               const parentData = _.find(parents, { userId });
               parentsEmails.push(parentData.email);
               parentsNames.push(parentData.name);

--- a/lib/export-csv.js
+++ b/lib/export-csv.js
@@ -21,26 +21,32 @@ function cmd_export_dojo_users (args, callback) {
   }
   // Returns the parent email of a child
   function getParentEmail (csvData, done) {
-    // filter to get children
-    async.eachSeries(csvData, function (row, cb) {
-      if (_.includes(row.Type, 'attendee')) {
-        seneca.act({role: 'cd-profiles', cmd: 'load_parents_for_user', userId: row.UserId, user: args.user}, function (err, parents) {
-          if (err) return cb(null);
-          var emails = _.map(parents, 'email').join(', ');
-          var names = _.map(parents, 'name').join(', ');
-          row['Parent Emails'] = emails;
-          row['Parent Names'] = names;
-          return cb(null, row);
+    var nbParents = [];
+    var parentsIds = _.compact(_.map(csvData, 'Parents'));
+    // Note: in case of optimisation, most parents profile are probably already loaded in getUserData
+    // This query ensure that parents that don't belongs to the dojo are still reachable
+    seneca.act({ role: 'cd-profiles', cmd: 'list', query: { userId: { in$: parentsIds } } },
+      (err, parents) => {
+        if (err) return done(err);
+        csvData.forEach((user) => {
+          user['Parent Emails'] = '';
+          user['Parent Names'] = '';
+          if (user['Parents']) {
+            const parentsEmails = [];
+            const parentsNames = [];
+            user['Parents'].map(userId => {
+              const parentData = _.find(parents, { userId });
+              parentsEmails.push(parentData.email);
+              parentsNames.push(parentData.name);
+            });
+            user['Parent Emails'] = parentsEmails.join(', ');
+            user['Parent Names'] = parentsNames.join(', ');
+          }
+          delete user['Parents'];
         });
-      } else {
-        row['Parent Emails'] = '';
-        row['Parent Names'] = '';
-        return cb(null, row);
-      }
-    }, function (err) {
-      if (err) return callback(err);
-      return done(null, csvData);
-    });
+        return done(null, csvData);
+      }  
+    );
   }
 
   function getUsersAttendances (csvData, done) {
@@ -65,6 +71,12 @@ function cmd_export_dojo_users (args, callback) {
   }
 
   function getUserData (done) {
+    var query = {
+      dojoId: args.dojoId,
+      deleted: 0,
+      fields: ['name', 'email', 'init_user_type', 'profile_id', 'dob', 'user_id', 'parents'],
+      limit$: 'NULL'
+    };
     seneca.act({role: plugin, cmd: 'load_dojo_users', query: query}, function (err, responses) {
       if (err) return callback(err);
       responses = responses.response;
@@ -75,7 +87,7 @@ function cmd_export_dojo_users (args, callback) {
         user['Type'] = JSON.parse(response.initUserType).name || '';
         user['UserId'] = response.userId;
         user['Age'] = Math.floor((new Date() - new Date(response.dob)) / (3600 * 1000 * 24 * 365));
-
+        user['Parents'] = response.parents;
         return cb(null, user);
       }, function (err, csvData) {
         if (err) return callback(null, {error: err});

--- a/lib/export-csv.js
+++ b/lib/export-csv.js
@@ -9,7 +9,7 @@ var async = require('async');
 function cmd_export_dojo_users (args, callback) {
   var seneca = this;
   var plugin = args.role;
-  var query = {
+  var baseQuery = {
     dojoId: args.dojoId,
     deleted: 0,
     limit$: 'NULL'
@@ -51,7 +51,7 @@ function cmd_export_dojo_users (args, callback) {
 
   function getUsersAttendances (csvData, done) {
     var groupedAtt = {};
-    query.userId = {in$: _.map(csvData, 'UserId')};
+    const query = Object.assign(baseQuery, { userId: { in$: _.map(csvData, 'UserId') } });
     seneca.act({role: 'cd-events', cmd: 'searchApplications', query: query}, function (err, attendances) {
       if (err) return callback(err);
       _.each(attendances, function (attendance) {
@@ -71,12 +71,9 @@ function cmd_export_dojo_users (args, callback) {
   }
 
   function getUserData (done) {
-    var query = {
-      dojoId: args.dojoId,
-      deleted: 0,
-      fields: ['name', 'email', 'init_user_type', 'profile_id', 'dob', 'user_id', 'parents'],
-      limit$: 'NULL'
-    };
+    const query = Object.assign(baseQuery, {
+      fields: ['name', 'email', 'init_user_type', 'profile_id', 'dob', 'user_id', 'parents']
+    });
     seneca.act({role: plugin, cmd: 'load_dojo_users', query: query}, function (err, responses) {
       if (err) return callback(err);
       responses = responses.response;
@@ -95,7 +92,6 @@ function cmd_export_dojo_users (args, callback) {
       });
     });
   }
-
   async.waterfall([ getUserData, getParentEmail, getUsersAttendances, convertToCSV ], function (err, csv) {
     if (err) return callback(null, { error: err });
     return callback(null, { data: csv });


### PR DESCRIPTION
From 10+s to 0.6s (locally)
Mostly thanks to removal of user_profile_data (user-facing function, unecessary for a csv export) (which means that, yes, you can contact a parent which is not part of your dojo if the kid is a part of it)
Should fix https://github.com/CoderDojo/community-platform/issues/1221
Other solutions if the ^ matter of not disclosing another's parent email: 
 - changing "eachSeries" to "each" works but still produces a 5+s just on getParentsEmail due to user_profile_data being slow
 - using the list of dojoMembers (which is already loaded) to base the parent Emails on. However, that means that >potentially< a kid may not have a parentEmail to be contacted with