### PR TITLE
Increased logging for email notifications

### DIFF
--- a/email-notifications.js
+++ b/email-notifications.js
@@ -30,6 +30,7 @@ module.exports = function (options) {
     var locale = args.locality;
     var code = args.code;
     if (options.sendemail && options.email) {
+      logger.warn('email-notifications', JSON.stringify(args));
       emailCode = code + locale;
       if (!fs.existsSync(CpTranslations.getEmailTemplatePath(emailCode))) emailCode = code + 'en_US';
       if (!args.to) return done(null, {ok: false, why: 'No recipient set.'});
@@ -37,11 +38,15 @@ module.exports = function (options) {
       if (!bypassTranslation) {
         subjectTranslation = i18nHelper.getClosestTranslation(locale, subject);
         if (subjectTranslation === null) {
+          logger.warn('email-notifications', JSON.stringify({
+            ok: false,
+            why: 'Invalid email subject.',
+            args
+          }));
           return done(null, {ok: false, why: 'Invalid email subject.'});
         }
         subject = subjectTranslation.fetch(subjectVariables);
       }
-      logger.warn('email-notifications', JSON.stringify(args));
       seneca.act({
         role: 'mail', cmd: 'send',
         from: args.from || options.sendFrom,

--- a/lib/controllers/dojo/submit.js
+++ b/lib/controllers/dojo/submit.js
@@ -17,6 +17,7 @@ module.exports = function (args, done) {
   var env = seneca.options().env;
   var zenHostname = env.hostname;
   var protocol = env.protocol;
+  const logger = require('cp-logs-lib')({ name: 'cp-dojos-service', level: 'warn' }).logger;
 
   async.waterfall([
     // Set the initial dojo status : awaiting approval
@@ -79,8 +80,10 @@ module.exports = function (args, done) {
         payload: payload},
         function (err, res) {
           if (err) {
+            logger.warn('submit-dojo', err);
             return cb(err);
           }
+          logger.warn('submit-dojo', res);
           cb(null, savedDojo);
         });
       } else {


### PR DESCRIPTION
After investigation, it seems our service is just never sends the email. Beyond that though, I've yet to come up with as much as a theory - I can't see any reason why one email would work and the other wouldn't while no code changes have occurred in the function to cause them to break... It's a real head scratcher...

There's two scenarios where the email isn't sent, but done is called but with no error. We should be able to identify if either of those are happening with this change.

I've also noticed that the failure to send came right after #411 was merged. Code-wise, this couldn't cause this issue, but perhaps something strange with the deployment?

My only issue with "let's add more logs" is when we'll actually get an answer to what's going on...

@Wardormeur Do you think we should add more logs around the new-dojo email to catch as much info as possible (mainly, I'm thinking we want to catch when code execution stops).