### PR TITLE
Add dojo name to the email

### DIFF
--- a/lib/dojos/users/notify.js
+++ b/lib/dojos/users/notify.js
@@ -28,7 +28,7 @@ module.exports = function notify (args, done) {
     function getDojoData (wfCb) {
       seneca.act({role: plugin, cmd: 'load', id: dojoId}, function (err, dojo) {
         if (err) return done(err);
-        payload.from = dojo.email;
+        payload.from = '"' + dojo.name + '" <' + dojo.email + '>';
         payload.replyTo = dojo.email;
         payload.locality = args.locality || 'en_US';
         payload.content.dojoName = dojo.name;


### PR DESCRIPTION
It's cheap and was part of my review regarding a crash on emailing.