### PR TITLE
Prevent deleted dojo from matching with duplicate lead

### DIFF
--- a/lib/controllers/lead/save.js
+++ b/lib/controllers/lead/save.js
@@ -34,7 +34,7 @@ module.exports = function (args, done) {
           var mergedList = _.map(leads, function (lead) {
             var dojo = _.find(dojos, { dojoLeadId: lead.id });
             if (dojo) {
-              if (dojo.verified) lead = undefined;
+              if (dojo.verified || dojo.deleted) lead = undefined;
               if (!dojo.verified) lead.dojo = dojo;
             }
             return lead;


### PR DESCRIPTION
Some Dojo leads are linked to multiple Dojos which preventes a user from
completing a new Dojo application.

This will allow the user workflow to progress.
A separate investigation into the duplicate lead issue needs to be done
for a longer term fix.